### PR TITLE
🐛 Tela de login apresentando header arrumado

### DIFF
--- a/src/components/CarouselForCertifications/ButtonForCertification/ButtonForCertification.vue
+++ b/src/components/CarouselForCertifications/ButtonForCertification/ButtonForCertification.vue
@@ -5,7 +5,7 @@
       :icon="props.icon"
       class="bg-indigo-8"
       color="white"
-      rounded
+      round
       @click="navSlides()"
     />
   </div>

--- a/src/components/CarouselForCertifications/CardForCertications/CardCertification.vue
+++ b/src/components/CarouselForCertifications/CardForCertications/CardCertification.vue
@@ -7,12 +7,7 @@
       </div>
     </q-card-section>
     <q-card-section>
-      <q-img
-        :src="props.imgsEx"
-        :height="props.height"
-        :width="props.width"
-        class="full-height"
-      />
+      <q-img :src="props.imgsEx" />
     </q-card-section>
   </q-card>
 </template>
@@ -23,14 +18,6 @@ const props = defineProps({
     default: "",
   },
   title: {
-    type: String,
-    default: "",
-  },
-  width: {
-    type: String,
-    default: "",
-  },
-  height: {
     type: String,
     default: "",
   },

--- a/src/components/CarouselForCertifications/CarouselCertifications.vue
+++ b/src/components/CarouselForCertifications/CarouselCertifications.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="div-carousel">
-    <q-carousel v-model="slide" class="full-height">
+  <div>
+    <q-carousel v-model="slide" class="full-height bg-transparent">
       <q-carousel-slide
         :name="index"
         class="overflow-hidden row no-wrap justify-center"
@@ -8,12 +8,9 @@
       >
         <CardCertification
           v-if="index > 0"
-          class="col-3 mt-12 card-left relative-position"
-          offset="2"
+          class="col-5 mt-12 card-left relative-position"
           :imgs-ex="imgs[index - 1].img"
           :title="imgs[index - 1].title"
-          width="500px"
-          height="1000px"
         />
         <ButtonForCertification
           v-if="index > 0"
@@ -24,8 +21,7 @@
         <CardCertification
           :imgs-ex="item.img"
           :title="item.title"
-          width="1200px"
-          height="1000px"
+          class="col-5 relative-position"
         />
         <ButtonForCertification
           v-if="index < imgs.length - 1"
@@ -36,12 +32,9 @@
         />
         <CardCertification
           v-if="index < imgs.length - 1"
-          class="col-3 mt-12 card-right relative-position"
-          offset="1"
+          class="col-5 mt-12 card-right relative-position"
           :imgs-ex="imgs[index + 1].img"
           :title="imgs[index + 1].title"
-          width="500px"
-          height="1000px"
         />
       </q-carousel-slide>
     </q-carousel>

--- a/src/components/Image/BackgroundIntranet.vue
+++ b/src/components/Image/BackgroundIntranet.vue
@@ -1,7 +1,7 @@
 <template>
   <q-img
     src="/INTRANET_BACKGROUND_ FUNDIMISA.png"
-    class="absolute opacity fixed-full"
+    class="absolute opacity position-fixed fixed-full"
   />
 </template>
 <style scoped>

--- a/src/components/Pages/PageCertifications/PCertification.vue
+++ b/src/components/Pages/PageCertifications/PCertification.vue
@@ -1,3 +1,3 @@
 <template>
-  <CarouselCertifications />
+  <CarouselCertifications class="pt-33" />
 </template>

--- a/src/components/Pages/PageCertifications/PCertification.vue
+++ b/src/components/Pages/PageCertifications/PCertification.vue
@@ -1,3 +1,8 @@
 <template>
-  <CarouselCertifications class="pt-33" />
+  <CarouselCertifications class="padding relative-position" />
 </template>
+<style scoped>
+.padding {
+  top: 10%;
+}
+</style>

--- a/src/components/Pages/RhDivulga/PRhDivulga.vue
+++ b/src/components/Pages/RhDivulga/PRhDivulga.vue
@@ -1,9 +1,9 @@
 <template>
-  <ImageRh class="padding" />
-  <Separator texto="DESTAQUES" large="300px" class="pt-8" />
+  <ImageRh img="RH_DIVULGA.png" class="padding" />
+  <Separator texto="DESTAQUES" large="px-20" class="pt-7 z-top" />
   <CarouselAtendimentoRh />
   <Carousel />
-  <Separator texto="OUTROS" large="300px" />
+  <Separator texto="OUTROS" large="px-20" />
   <Item class="pt-12" />
 </template>
 <style scoped>

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -1,4 +1,8 @@
-<template></template>
+<template>
+  <div>
+    <h1>{{ $t("about") }}</h1>
+  </div>
+</template>
 
 <script setup lang="ts">
 import { router } from "../modules";

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -1,1 +1,9 @@
-<template><Login /></template>
+<template></template>
+
+<script setup lang="ts">
+import { router } from "../modules";
+
+onMounted(() => {
+  router.push("/login");
+});
+</script>


### PR DESCRIPTION
![image](https://github.com/partithura-estagiarios/intranet-fdms-front/assets/107896110/6687c23c-56a7-4be3-8f2b-f5262f6b0661)
após a arrumação do erro  
![image](https://github.com/partithura-estagiarios/intranet-fdms-front/assets/107896110/8ea3f06e-8d5c-425d-87ad-9f4472e7bc0a)
Obs 1: Header tapando as certifications 
![image](https://github.com/partithura-estagiarios/intranet-fdms-front/assets/107896110/962d70e9-acb5-428a-b2f3-21de68402f0f)
Obs 2: Página RH divulga sem um background e o separator destaques estava sendo cobrido pelo carousel debaixo 
![image](https://github.com/partithura-estagiarios/intranet-fdms-front/assets/107896110/6deaee68-80d4-48d5-8549-fc2f55084bd7)
