### PR TITLE
Bug/arrumand-err-de-int-e-id-das-querys-de-ramais

### DIFF
--- a/src/components/TableRamais/Table.vue
+++ b/src/components/TableRamais/Table.vue
@@ -64,7 +64,7 @@ async function getRamais(page: number) {
   saveIndexPages.value = page;
   const { ramaisForPageLoad }: { ramaisForPageLoad: Array<Ramal> } =
     await runQuery(RamaisForPageLoad, {
-      page: page.toString(),
+      page: saveIndexPages.value,
     });
 
   ramais.value = ramaisForPageLoad;
@@ -74,7 +74,7 @@ async function getSizeOfRamais() {
   const { getLenghtRamais }: { getLenghtRamais: String } = await runQuery(
     GetLenghtRamais,
     {
-      maxPages: pagesOfTable.toString(),
+      maxPages: pagesOfTable,
     },
   );
   pages.value = getLenghtRamais;

--- a/src/graphql/ramais/GetLenghtRamais.gql
+++ b/src/graphql/ramais/GetLenghtRamais.gql
@@ -1,3 +1,3 @@
-query GetLenghtRamais($maxPages: ID!) {
+query GetLenghtRamais($maxPages: Int!) {
   getLenghtRamais(maxPages: $maxPages)
 }

--- a/src/graphql/ramais/RamaisForPageLoad.gql
+++ b/src/graphql/ramais/RamaisForPageLoad.gql
@@ -1,4 +1,4 @@
-query RamaisForPageLoad($page: ID!) {
+query RamaisForPageLoad($page: Int!) {
   ramaisForPageLoad(page: $page) {
     id
     name

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -6,7 +6,7 @@ const GRAPHQL_ERROR_MARKER = 9;
 
 export async function runQuery<T>(
   query: MaybeRef<DocumentNode | string>,
-  variables: Record<string, string> | null = null,
+  variables: Record<string, unknown> | null = null,
 ): Promise<T> {
   const { data, error } = await useQuery({
     query,


### PR DESCRIPTION
As querys que buscavam os ramais e também retornavam os numeros de páginas estavam enviando ID pro Back que esperava um Int, então arrumei isso