### PR TITLE
Bug/resolvendo-bug-de-criador-de-sala-material-de-apoio

### DIFF
--- a/src/components/ShowScheduleRoom/DialogScheduleRoom.vue
+++ b/src/components/ShowScheduleRoom/DialogScheduleRoom.vue
@@ -32,7 +32,11 @@
       <q-icon :name="item?.toString()" size="sm" />
       <p>{{ $t("text." + index) }}</p>
     </div>
-    <q-icon name="new_releases" size="sm" />
+    <q-icon
+      name="new_releases"
+      size="sm"
+      v-show="helpersValueFromMaterialSup"
+    />
     <p>{{ helpersValueFromMaterialSup }}</p>
   </q-card-section>
 </template>

--- a/src/components/ShowScheduleRoom/lib.ts
+++ b/src/components/ShowScheduleRoom/lib.ts
@@ -24,7 +24,7 @@ export function renameKeys(materialsSup: SuPMaterials) {
 
   Object.keys(materialsSup).forEach((key) => {
     const validKey = key as ValidKeys;
-    if (translations[validKey]) {
+    if (translations[validKey] && materialsSup[validKey] === true) {
       materialsSup[validKey] = translations[validKey];
     }
   });


### PR DESCRIPTION
Ao clicar em mostrar os detalhes da reunião ele estava mostrando itens que não foram marcados para se trazer a reunião