### PR TITLE
Bugfix/validar-campos-antes-de-agendar-evento

### DIFF
--- a/src/components/ScheduleRoom/SectionOfInput/InputNormal.vue
+++ b/src/components/ScheduleRoom/SectionOfInput/InputNormal.vue
@@ -95,8 +95,8 @@ watchEffect(() => {
 
 <style scoped>
 .border {
-  border: 1px rgb(29, 29, 167) solid;
-  border-radius: 2px;
+  border: 0.1rem rgb(31, 73, 125) solid;
+  border-radius: 0.2rem;
 }
 .custom-color {
   background-color: rgb(31, 73, 125);

--- a/src/components/ScheduleRoom/addScheduleRoom/AddScheduleRoom.vue
+++ b/src/components/ScheduleRoom/addScheduleRoom/AddScheduleRoom.vue
@@ -11,6 +11,7 @@
         color="green"
         :label="$t('formRamal.confirm')"
         @click="saveRoom()"
+        :disable="disableSaveRoom"
       />
     </div>
   </q-card-section>
@@ -18,7 +19,7 @@
 
 <script setup lang="ts">
 import CreateScheduleRoom from "../../../graphql/scheduleRoom/CreateScheduleRoom.gql";
-import { adaptScheduleToRoom } from "../addScheduleRoom/lib";
+import { adaptScheduleToRoom, fieldsValid } from "../addScheduleRoom/lib";
 import { DateTime } from "luxon";
 import { StatusCreateMeeting } from "../../../support/contracts";
 const { t } = useI18n();
@@ -39,6 +40,7 @@ const notifyUser = (message: string, type: string) => {
   }
   negativeNotify(message);
 };
+const disableSaveRoom = computed(() => !fieldsValid(roomSchedule.value));
 
 async function saveRoom() {
   roomSchedule.value = adaptScheduleToRoom(roomSchedule.value);

--- a/src/components/ScheduleRoom/addScheduleRoom/lib.ts
+++ b/src/components/ScheduleRoom/addScheduleRoom/lib.ts
@@ -74,3 +74,37 @@ export function adaptScheduleToRoom(schedule: InputsForScheduleRoom) {
     },
   };
 }
+
+export function fieldsValid(schedule: InputsForScheduleRoom) {
+  if (!validInputsNormals(schedule)) {
+    return false;
+  }
+  if (!validDateInput(schedule)) {
+    return false;
+  }
+  return true;
+}
+
+export function validInputsNormals(schedule: InputsForScheduleRoom) {
+  if (
+    !schedule.inputs ||
+    !schedule.options.value ||
+    !schedule.inputsLongs.description
+  ) {
+    return false;
+  }
+  const properties = Object.values(schedule.inputs);
+  return properties.every((property) => {
+    return property.value !== null && property.value !== "";
+  });
+}
+
+export function validDateInput(schedule: InputsForScheduleRoom) {
+  if (!schedule.dateInfos) {
+    return false;
+  }
+  const properties = Object.values(schedule.dateInfos);
+  return properties.every((property) => {
+    return property.value !== undefined;
+  });
+}

--- a/src/stores/events.ts
+++ b/src/stores/events.ts
@@ -3,8 +3,7 @@ import LoadEventsInData from "../graphql/scheduleRoom/LoadEventsInData.gql";
 import NextEvents from "../graphql/scheduleRoom/NextEvents.gql";
 
 import { DateTime } from "luxon";
-import { set } from "zod";
-import { stat } from "fs";
+
 import { EventRoom } from "../entities/scheduleRoom";
 const id = "events";
 


### PR DESCRIPTION
Agora é o botão de confirmar só fica ativo quando o usuário preenche os inputs sobre suas informações e da sala("sala respectiva da reunião", "data de início e término da reunião" e "título para reunião" 
![image](https://github.com/partithura-estagiarios/intranet-fdms-front/assets/107896110/1c738768-fdc4-4c16-8e53-1359aa33c0a2)
preenchido 
![image](https://github.com/partithura-estagiarios/intranet-fdms-front/assets/107896110/5f769120-67c4-4aed-8398-de4d958a6c1c)
