### PR TITLE
feature/event-counts-by-month

### DIFF
--- a/locales/br/label.ts
+++ b/locales/br/label.ts
@@ -13,4 +13,8 @@ export default {
     november: "Novembro",
     december: "Dezembro",
   },
+  year: "Ano",
+  month: "Mês",
+  day: "Dia",
+  week: "Semana",
 };

--- a/locales/en/label.ts
+++ b/locales/en/label.ts
@@ -13,4 +13,8 @@ export default {
     november: "November",
     december: "December",
   },
+  year: "Year",
+  month: "Month",
+  day: "Day",
+  week: "Week",
 };

--- a/src/components/Pages/ScheduleRoom/AuxButtonsForSchedule/ButtonGoScheduleYear.vue
+++ b/src/components/Pages/ScheduleRoom/AuxButtonsForSchedule/ButtonGoScheduleYear.vue
@@ -1,0 +1,34 @@
+<template>
+  <q-list class="rounded-borders text-white bg-green" v-for="item in items">
+    <q-item
+      clickable
+      v-ripple
+      :class="getItemClass(item)"
+      @click="selectItem(item)"
+    >
+      <q-item-section>{{ $t(`label.${item}`) }}</q-item-section>
+    </q-item>
+  </q-list>
+</template>
+
+<script setup lang="ts">
+const items = ["month", "week", "day", "year"];
+const emits = defineEmits(["changeSchedule"]);
+const selectedItem = ref<string | null>("month");
+
+function selectItem(item: string) {
+  selectedItem.value = item;
+  emits("changeSchedule", item);
+}
+
+const getItemClass = (item: string) => {
+  return selectedItem.value === item ? "my-menu-link" : "";
+};
+</script>
+
+<style scoped>
+.my-menu-link {
+  color: white;
+  background-color: rgb(31, 73, 125);
+}
+</style>

--- a/src/components/ScheduleRoom/CardGridMonths/CardGridMonths.vue
+++ b/src/components/ScheduleRoom/CardGridMonths/CardGridMonths.vue
@@ -1,7 +1,15 @@
 <template>
   <div class="row">
-    <q-card v-for="month in monthsAux" class="color-custom q-py-md col-3"
-      >{{ $t(`label.months.${month.label}`) }}
+    <q-card v-for="month in monthsAux" class="color-custom q-py-md col-3">
+      <q-item>
+        <q-item-section>
+          <q-item-label class="text-hover-custom cursor-pointer">{{
+            $t(`label.months.${month.label}`)
+          }}</q-item-label>
+          <q-item-label class="text-hover-custom cursor-pointer"></q-item-label>
+          <q-badge color="red" floating>12</q-badge>
+        </q-item-section>
+      </q-item>
     </q-card>
   </div>
 </template>
@@ -13,5 +21,8 @@ import { monthsAux } from "./lib";
 <style scoped>
 .color-custom {
   color: rgb(31, 73, 125);
+}
+.text-hover-custom:hover {
+  color: green;
 }
 </style>


### PR DESCRIPTION
Adiciona uma nova funcionalidade que permite ao usuário clicar em um botão para visualizar uma lista de meses, acompanhada da quantidade de eventos ocorridos em cada mês. Esta melhoria ajuda a obter uma visão geral rápida da distribuição de eventos ao longo do ano.

Detalhes:

+Adicionado um botão que, ao ser clicado, exibe uma lista de meses.
+Cada mês na lista é acompanhado pelo número total de eventos registrados.

![image](https://github.com/user-attachments/assets/7f36e5d6-a185-48a7-b465-9de2d2e8e087)
Quando se passa o mouse em cima do nome do mês ele muda a cor para mostrar que está selecionado 
![image](https://github.com/user-attachments/assets/89394029-ec40-4cbf-a6e0-7c6c196900bd)
