### PR TITLE
Feature/month-events-badge

### DIFF
--- a/locales/br/text.ts
+++ b/locales/br/text.ts
@@ -57,4 +57,5 @@ export default {
   nameRoom: "Nome da Sala",
   colorRoom: "Cor",
   pleaseWait: "Por favor aguarde",
+  eventsInMonth: "Eventos No Mês",
 };

--- a/locales/en/text.ts
+++ b/locales/en/text.ts
@@ -56,4 +56,5 @@ export default {
   nameRoom: "Name Room",
   colorRoom: "Color",
   pleaseWait: "Please Wait",
+  eventsInMonth: "Events in Month",
 };

--- a/src/components/Pages/ScheduleRoom/AuxButtonsForSchedule/ButtonGoScheduleYear.vue
+++ b/src/components/Pages/ScheduleRoom/AuxButtonsForSchedule/ButtonGoScheduleYear.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script setup lang="ts">
-const items = ["month", "week", "day", "year"];
+const items = ["month", "year"];
 const emits = defineEmits(["changeSchedule"]);
 const selectedItem = ref<string | null>("month");
 

--- a/src/components/ScheduleRoom/CardGridMonths/BadgeEventsInMonth.vue
+++ b/src/components/ScheduleRoom/CardGridMonths/BadgeEventsInMonth.vue
@@ -1,0 +1,16 @@
+<template>
+  <q-badge color="red" floating class="text-body2">
+    <q-tooltip anchor="center right" self="center left" :offset="[10, 10]">
+      {{ $t("text.eventsInMonth") }}
+    </q-tooltip>
+    {{ props.month.events.length }}</q-badge
+  >
+</template>
+
+<script setup lang="ts">
+import { Month } from "../../../stores/months";
+
+const props = defineProps<{
+  month: Month;
+}>();
+</script>

--- a/src/components/ScheduleRoom/CardGridMonths/CardGridMonths.vue
+++ b/src/components/ScheduleRoom/CardGridMonths/CardGridMonths.vue
@@ -1,13 +1,16 @@
 <template>
   <div class="row">
-    <q-card v-for="month in monthsAux" class="color-custom q-py-md col-3">
+    <q-card
+      v-for="month in monthsStorage.months"
+      class="color-custom q-py-md col-3"
+    >
       <q-item>
         <q-item-section>
           <q-item-label class="text-hover-custom cursor-pointer">{{
-            $t(`label.months.${month.label}`)
+            $t(`label.months.${month.name}`)
           }}</q-item-label>
           <q-item-label class="text-hover-custom cursor-pointer"></q-item-label>
-          <q-badge color="red" floating>12</q-badge>
+          <BadgeEventsInMonth :month="month" />
         </q-item-section>
       </q-item>
     </q-card>
@@ -16,6 +19,11 @@
 
 <script setup lang="ts">
 import { monthsAux } from "./lib";
+import { useMonths } from "../../../stores/months";
+const monthsStorage = useMonths();
+onMounted(async () => {
+  await monthsStorage.loadEvents(monthsAux);
+});
 </script>
 
 <style scoped>

--- a/src/graphql/scheduleRoom/LoadAllEventsInMonth.gql
+++ b/src/graphql/scheduleRoom/LoadAllEventsInMonth.gql
@@ -1,0 +1,29 @@
+query LoadAllEventsInMonth($month: String!) {
+  loadAllEventsInMonth(month: $month) {
+    id
+    host {
+      name
+      ramalNumber
+      userRegistration
+      email
+    }
+    location {
+      id
+      name
+      color
+    }
+    rules
+    totalPeoples
+    initialTime
+    finalTime
+    support {
+      computer
+      projector
+      water
+      coffee
+      flipSharp
+      equipamentSong
+      helpers
+    }
+  }
+}

--- a/src/stores/months.ts
+++ b/src/stores/months.ts
@@ -1,0 +1,39 @@
+import { defineStore } from "pinia";
+import { EventRoom } from "../entities/scheduleRoom";
+import LoadAllEventsInMonth from "../graphql/scheduleRoom/LoadAllEventsInMonth.gql";
+const id = "months";
+export interface Month {
+  name: string;
+  events: EventRoom[];
+}
+export interface AuxMonth {
+  label: string;
+  value: number;
+}
+
+interface State {
+  months: Month[];
+}
+export const useMonths = defineStore(id, {
+  state: (): State => ({
+    months: [],
+  }),
+  getters: {},
+  actions: {
+    loadEvents: async (months: AuxMonth[]) => {
+      const monthsStorage = useMonths();
+      monthsStorage.months = [];
+      const promises = months.map(async (mes: AuxMonth) => {
+        const { loadAllEventsInMonth }: { loadAllEventsInMonth: EventRoom[] } =
+          await runQuery(LoadAllEventsInMonth, { month: mes.label });
+        return {
+          name: mes.label,
+          events: loadAllEventsInMonth,
+          value: mes.value,
+        };
+      });
+      const monthsData = await Promise.all(promises);
+      monthsStorage.months = monthsData.sort((a, b) => a.value - b.value);
+    },
+  },
+});


### PR DESCRIPTION
Adiciona uma badge à visualização mensal que exibe a contagem de eventos para cada mês.

Detalhes:

+Nova Store: useMonths gerencia os meses e a contagem de eventos.
+Badge de Contagem: Adicionada ao componente mensal.
+Consulta ao Backend: Atualizada para buscar a contagem de eventos por mês.
Mudanças:

+Store useMonths: Implementada para gerenciar a contagem de eventos.
+Componente de Mês: Atualizado para exibir a badge com a contagem.

Capturas de Tela: 
![image](https://github.com/user-attachments/assets/bbf51ac8-86de-46c1-bf37-5b2d0abf2856)
