### PR TITLE
✨ Adiciona exibição de card com eventos do mês ao clicar na badge"

### DIFF
--- a/src/components/ScheduleRoom/CardGridMonths/BadgeEventsInMonth.vue
+++ b/src/components/ScheduleRoom/CardGridMonths/BadgeEventsInMonth.vue
@@ -1,14 +1,27 @@
 <template>
-  <q-badge color="red" floating class="text-body2">
+  <q-badge
+    color="red"
+    floating
+    class="text-body2 cursor-pointer"
+    @click="enableCard = true"
+  >
     <q-tooltip anchor="center right" self="center left" :offset="[10, 10]">
       {{ $t("text.eventsInMonth") }}
     </q-tooltip>
-    {{ props.month.events.length }}</q-badge
-  >
+    {{ props.month.events.length }}
+    <CardEventsInMonth
+      :open="enableCard"
+      @close="enableCard = false"
+      :monthName="props.month.name"
+      :events="props.month.events"
+    />
+  </q-badge>
 </template>
 
 <script setup lang="ts">
 import { Month } from "../../../stores/months";
+
+const enableCard = ref(false);
 
 const props = defineProps<{
   month: Month;

--- a/src/components/ScheduleRoom/CardGridMonths/CardAllEventsInMonth/AllEventsInMonth.vue
+++ b/src/components/ScheduleRoom/CardGridMonths/CardAllEventsInMonth/AllEventsInMonth.vue
@@ -1,0 +1,67 @@
+<template>
+  <q-card-section class="row text-black justify-center" vertical>
+    <div
+      v-for="item in props.events"
+      :key="item.id"
+      @click="selectEvent(item)"
+      class="cursor-pointer col-3 q-px-sm q-py-sm"
+    >
+      <q-badge :style="`background-color:${item.location.color}`" />
+      <span class="q-px-xs">{{ item.host.name }} </span>
+    </div>
+  </q-card-section>
+  <q-dialog v-model="card">
+    <q-card>
+      <q-card-section class="custom-color row justify-between text-white">
+        <div class="q-pa-md text-h5 font-custom text-white">
+          {{ eventSelected.rules }}
+        </div>
+        <q-icon
+          name="close"
+          class="pt-2 cursor-pointer"
+          size="3rem"
+          @click="card = !card"
+        />
+      </q-card-section>
+      <q-separator />
+      <DialogScheduleRoom :event-show="eventSelected" />
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { EventRoom } from "../../../../entities/scheduleRoom";
+import { DateTime } from "luxon";
+const props = defineProps({
+  events: {
+    type: Array as () => EventRoom[],
+    required: true,
+  },
+});
+
+const card = ref();
+const eventSelected = ref();
+function selectEvent(event: EventRoom) {
+  card.value = true;
+  const initialTime = DateTime.fromISO(event.initialTime.toString()).plus({
+    hours: 3,
+  });
+  const finalTime = DateTime.fromISO(event.finalTime.toString()).plus({
+    hours: 3,
+  });
+  const auxEvent = {
+    ...event,
+    initialTime: DateTime.fromISO(initialTime.toString()),
+    finalTime: DateTime.fromISO(finalTime.toString()),
+  };
+  eventSelected.value = auxEvent;
+}
+</script>
+<style scoped>
+.custom-color {
+  background-color: rgb(31, 73, 125);
+}
+.font-custom {
+  font-family: Fira Sans;
+}
+</style>

--- a/src/components/ScheduleRoom/CardGridMonths/CardAllEventsInMonth/CardEventsInMonth.vue
+++ b/src/components/ScheduleRoom/CardGridMonths/CardAllEventsInMonth/CardEventsInMonth.vue
@@ -1,0 +1,41 @@
+<template>
+  <q-dialog v-model="card" :persistent="true">
+    <q-card class="my-card">
+      <DialogHeader option="Eventos" @close="closeCard" />
+      <TitleCardEventsMonth
+        :monthName="props.monthName"
+        class="justify-center"
+      />
+      <AllEventsInMonth :events="eventsCard" />
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { EventRoom } from "../../../../entities/scheduleRoom";
+import { Month } from "../../../../stores/months";
+
+const emits = defineEmits(["close"]);
+const props = defineProps({
+  open: {
+    type: Boolean,
+    required: true,
+  },
+  monthName: {
+    type: String,
+    required: true,
+  },
+  events: {
+    type: Array as () => EventRoom[],
+  },
+});
+const card = ref();
+const eventsCard = ref(props.events || []);
+watchEffect(() => {
+  card.value = props.open;
+});
+function closeCard() {
+  card.value = true;
+  emits("close");
+}
+</script>

--- a/src/components/ScheduleRoom/CardGridMonths/CardAllEventsInMonth/TitleCardEventsMonth.vue
+++ b/src/components/ScheduleRoom/CardGridMonths/CardAllEventsInMonth/TitleCardEventsMonth.vue
@@ -1,0 +1,49 @@
+<template>
+  <q-card-section class="text-black row">
+    <div class="border space-reserved">
+      <q-btn flat icon="arrow_back" class="custom-color" size="xl" />
+    </div>
+    <div class="border space-reserved-name-month">
+      <q-separator color="green" size="0.1rem" />
+      <q-chip
+        color="transparent"
+        class="text-capitalize text-indigo-8 text-h6 font-custom"
+        >{{ props.monthName }}</q-chip
+      >
+      <q-separator color="green" size="0.1rem" />
+    </div>
+    <div class="border space-reserved">
+      <q-btn
+        flat
+        icon="arrow_forward"
+        clickable
+        class="custom-color"
+        size="xl"
+      />
+    </div>
+  </q-card-section>
+</template>
+
+<script setup lang="ts">
+import { Month } from "../../../../stores/months";
+
+const props = defineProps({
+  monthName: {
+    type: String,
+    required: true,
+  },
+});
+</script>
+
+<style scoped>
+.custom-color {
+  color: rgb(31, 73, 125);
+}
+.font-custom {
+  font-family: Fira Sans;
+  align-items: center;
+}
+.space-reserved {
+  width: 5rem;
+}
+</style>


### PR DESCRIPTION
Este Pull Request implementa a funcionalidade de exibir um card com todos os eventos do mês quando o usuário clica na badge correspondente. Abaixo estão os detalhes das alterações realizadas:

Funcionalidades Adicionadas:
-Interação com a Badge: Ao clicar na badge que mostra o número de eventos do mês, um card será exibido.
-Exibição dos Eventos: O card exibirá uma lista completa de eventos do mês selecionado.
-Fechamento do Card: O card pode ser fechado clicando no botão de fechamento no header do card ou fora dele, dependendo da configuração do diálogo. 

Como Acessar o Card => 
![2024-07-29_10-39](https://github.com/user-attachments/assets/64604f09-dc36-4e6b-a2e1-1e0b241e079a)



Card => 
![image](https://github.com/user-attachments/assets/c640b2fe-2d6b-4eb7-8f01-820ec21b4665)
