### PR TITLE
✨ Adiciona funcionalidade de seleção de mês para exibição de eventos

### DIFF
--- a/src/components/Pages/PageScheduleRoom/PScheduleRoom.vue
+++ b/src/components/Pages/PageScheduleRoom/PScheduleRoom.vue
@@ -58,7 +58,10 @@
             <BadgeEvents :data="timestamp.date" :events="events" />
           </template>
         </q-calendar-month>
-        <CardGridMonths v-if="slideSchedule == 'year'" />
+        <CardGridMonths
+          v-if="slideSchedule == 'year'"
+          @envity-month="goToSpecificMonth"
+        />
       </q-slide-transition>
     </div>
   </div>
@@ -85,7 +88,6 @@ const card = ref(false);
 const cardEvents = ref(false);
 const rooms = ref();
 const slideSchedule = ref("month");
-const reloadBeforeAdd = ref();
 const eventsDay = ref();
 const events = ref();
 
@@ -167,6 +169,15 @@ const reloadModalAddScheduleRoom = async () => {
 onMounted(() => {
   loadSchedule();
 });
+async function goToSpecificMonth(targetYear: number, targetMonth: number) {
+  slideSchedule.value = "month";
+  await nextTick();
+  if (selectedDate) {
+    const targetDate = `${targetYear}-${String(targetMonth).padStart(2, "0")}-01`;
+    selectedDate.value = targetDate;
+    await nextTick();
+  }
+}
 </script>
 <style scoped>
 .custom-color {

--- a/src/components/Schedule/CalendarSchedularRoom/ToolbarCalendar.vue
+++ b/src/components/Schedule/CalendarSchedularRoom/ToolbarCalendar.vue
@@ -25,19 +25,12 @@
 </template>
 
 <script setup lang="ts">
-import { useEvents } from "../../../stores/events";
-
 const props = defineProps({
   date: {
     type: String,
     required: true,
   },
 });
-
-const eventStorage = useEvents();
-const card = ref(false);
-
-const openModalAddScheduleRoom = () => {};
 </script>
 <style scoped>
 .custom-toolbar {

--- a/src/components/Schedule/CardGridMonths/CardGridMonths.vue
+++ b/src/components/Schedule/CardGridMonths/CardGridMonths.vue
@@ -6,9 +6,11 @@
     >
       <q-item>
         <q-item-section>
-          <q-item-label class="text-hover-custom cursor-pointer">{{
-            $t(`label.months.${month.name}`)
-          }}</q-item-label>
+          <q-item-label
+            class="text-hover-custom cursor-pointer"
+            @click="goToSpecificMonth(month.name)"
+            >{{ $t(`label.months.${month.name}`) }}</q-item-label
+          >
           <BadgeEventsInMonth :month="month" />
         </q-item-section>
       </q-item>
@@ -20,9 +22,17 @@
 import { monthsAux } from "../../../stores/months";
 import { useMonths } from "../../../stores/months";
 const monthsStorage = useMonths();
+const emits = defineEmits(["envityMonth"]);
 onMounted(async () => {
   await monthsStorage.loadEvents(monthsAux);
 });
+
+async function goToSpecificMonth(monthName: string) {
+  const month = monthsAux.find(
+    (month) => month.label === monthName.toLowerCase(),
+  );
+  emits("envityMonth", new Date().getFullYear(), month?.numberMonth);
+}
 </script>
 
 <style scoped>

--- a/src/components/Schedule/ScheduleRoom/Month.vue
+++ b/src/components/Schedule/ScheduleRoom/Month.vue
@@ -7,6 +7,7 @@
 </template>
 
 <script setup lang="ts">
+import { DateTime } from "luxon";
 import { countryCodes } from "./lib";
 const props = defineProps({
   selectDate: {
@@ -15,21 +16,15 @@ const props = defineProps({
   },
 });
 const formattedMonth = computed(() => {
-  const date = new Date(props.selectDate);
+  const date = DateTime.fromISO(props.selectDate).toJSDate();
   return monthFormatter().format(date) + " " + date.getFullYear();
 });
 const country = ref("BR");
 function monthFormatter(): Intl.DateTimeFormat {
-  try {
-    return new Intl.DateTimeFormat(locale.value || undefined, {
-      month: "long",
-      timeZone: "UTC",
-    });
-  } catch (e) {
-    console.error("Failed to create DateTimeFormat:", e);
-    // Retornar um formato de data padrão em caso de erro
-    return new Intl.DateTimeFormat("en-US", { month: "long" });
-  }
+  return new Intl.DateTimeFormat(locale.value || undefined, {
+    month: "long",
+    timeZone: "UTC",
+  });
 }
 const locale = computed(() => {
   if (country.value) {

--- a/src/stores/months.ts
+++ b/src/stores/months.ts
@@ -2,18 +2,18 @@ import { defineStore } from "pinia";
 import { EventRoom } from "../entities/scheduleRoom";
 import LoadAllEventsInMonth from "../graphql/scheduleRoom/LoadAllEventsInMonth.gql";
 export const monthsAux = [
-  { label: "january", value: 1 },
-  { label: "february", value: 2 },
-  { label: "march", value: 3 },
-  { label: "april", value: 4 },
-  { label: "may", value: 5 },
-  { label: "june", value: 6 },
-  { label: "july", value: 7 },
-  { label: "august", value: 8 },
-  { label: "september", value: 9 },
-  { label: "october", value: 10 },
-  { label: "november", value: 11 },
-  { label: "december", value: 12 },
+  { label: "january", numberMonth: 1 },
+  { label: "february", numberMonth: 2 },
+  { label: "march", numberMonth: 3 },
+  { label: "april", numberMonth: 4 },
+  { label: "may", numberMonth: 5 },
+  { label: "june", numberMonth: 6 },
+  { label: "july", numberMonth: 7 },
+  { label: "august", numberMonth: 8 },
+  { label: "september", numberMonth: 9 },
+  { label: "october", numberMonth: 10 },
+  { label: "november", numberMonth: 11 },
+  { label: "december", numberMonth: 12 },
 ];
 
 function getPreviousMonth(monthName: string): string {
@@ -41,7 +41,7 @@ export interface Month {
 }
 export interface AuxMonth {
   label: string;
-  value: number;
+  numberMonth: number;
 }
 
 interface State {
@@ -62,7 +62,7 @@ export const useMonths = defineStore(id, {
         return {
           name: mes.label,
           events: loadAllEventsInMonth,
-          value: mes.value,
+          value: mes.numberMonth,
         };
       });
       const monthsData = await Promise.all(promises);


### PR DESCRIPTION
Este PR adiciona uma funcionalidade para selecionar um mês específico na visualização de eventos no calendário. A nova funcionalidade permite que os usuários escolham um mês e vejam os eventos agendados para esse mês

Detalhes da Implementação:

+Seleção de Mês: Foi adicionado um seletor de mês ao componente de calendário, permitindo aos usuários escolher o mês desejado.
+Atualização da Visualização: A visualização do calendário é atualizada para refletir o mês selecionado e exibir os eventos correspondentes.
+Manipulação de Data: Implementada a lógica para converter e formatar datas corretamente ao selecionar um mês.

Exemplos da utilização:
![2024-07-30_10-49](https://github.com/user-attachments/assets/bbf83f28-b702-4ee3-b318-6d3fadb9389f)

![image](https://github.com/user-attachments/assets/a53456ee-08a8-46f2-8d56-a92d275db2e0)
