### PR TITLE
✨ Adiciona navegação entre anos e exibição de eventos mensais

### DIFF
--- a/src/components/Pages/PageScheduleRoom/PScheduleRoom.vue
+++ b/src/components/Pages/PageScheduleRoom/PScheduleRoom.vue
@@ -1,7 +1,7 @@
 <template>
   <Separator :texto="$t('tab.scheduler')" />
   <ToolbarCalendar
-    :date="selectedDate || ''"
+    :date="selectedDate"
     @today="onToday"
     @prev="onPrev"
     @next="onNext"
@@ -85,7 +85,7 @@ import { TIME_MAKER, MIN_DAY_HEIGHT } from "../../../support/constants";
 
 const instance = getCurrentInstance();
 const eventStorage = useEvents();
-const selectedDate = ref<string | null>(today());
+const selectedDate = ref<string>(today());
 const { t } = useI18n();
 const card = ref(false);
 const cardEvents = ref(false);
@@ -210,7 +210,7 @@ async function goToSpecificYear(opt: string) {
       month: 1,
       day: 1,
     }).toISODate();
-    selectedDate.value = targetDate;
+    selectedDate.value = targetDate as string;
   }
 }
 </script>

--- a/src/components/Pages/PageScheduleRoom/PScheduleRoom.vue
+++ b/src/components/Pages/PageScheduleRoom/PScheduleRoom.vue
@@ -1,11 +1,12 @@
 <template>
   <Separator :texto="$t('tab.scheduler')" />
   <ToolbarCalendar
-    :date="selectedDate"
+    :date="selectedDate || ''"
     @today="onToday"
     @prev="onPrev"
     @next="onNext"
     @openModalAdd="openModalAddScheduleRoom"
+    :viewMode="viewMode"
   />
   <q-dialog v-model="card">
     <q-card>
@@ -36,16 +37,16 @@
   </q-dialog>
   <div class="row justify-center font-custom">
     <div class="q-px-sm">
-      <ButtonGoScheduleYear @change-schedule="(val) => (slideSchedule = val)" />
+      <ButtonGoScheduleYear @change-schedule="(val) => (viewMode = val)" />
     </div>
     <div class="text-h5 calendar-size text-uppercase">
       <q-slide-transition>
         <q-calendar-month
           ref="calendar"
-          v-if="slideSchedule == 'month'"
+          v-if="viewMode === TIME_MAKER.MONTH"
           v-model="selectedDate"
           locale="pt-br"
-          :day-min-height="100"
+          :day-min-height="MIN_DAY_HEIGHT"
           @click-day="onClickDay"
           class="cursor-pointer"
         >
@@ -59,8 +60,9 @@
           </template>
         </q-calendar-month>
         <CardGridMonths
-          v-if="slideSchedule == 'year'"
+          v-if="viewMode === TIME_MAKER.YEAR"
           @envity-month="goToSpecificMonth"
+          :year="selectedDate || ''"
         />
       </q-slide-transition>
     </div>
@@ -79,15 +81,16 @@ import LoadingEvent from "../../Loading/LoadingEvent.vue";
 import { DateTime } from "luxon";
 import { createEvent, getHeadDay } from "../../Schedule/ScheduleRoom/lib";
 import { CalendarItem, EventRoom } from "../../../entities/scheduleRoom";
+import { TIME_MAKER, MIN_DAY_HEIGHT } from "../../../support/constants";
 
 const instance = getCurrentInstance();
 const eventStorage = useEvents();
-const selectedDate = ref(today());
+const selectedDate = ref<string | null>(today());
 const { t } = useI18n();
 const card = ref(false);
 const cardEvents = ref(false);
 const rooms = ref();
-const slideSchedule = ref("month");
+const viewMode = ref(TIME_MAKER.MONTH);
 const eventsDay = ref();
 const events = ref();
 
@@ -114,7 +117,7 @@ const onClickDay = async (data: CalendarItem) => {
     ).toISODate();
     return eventInitialDate === date || eventFinalDate === date;
   });
-  if (eventsDay.value.length) {
+  if (eventsDay) {
     eventStorage.dataFull = date.toString();
     cardEvents.value = true;
     return eventsDay;
@@ -123,18 +126,27 @@ const onClickDay = async (data: CalendarItem) => {
 };
 
 function onToday() {
+  if (viewMode.value == TIME_MAKER.YEAR) {
+    return goToSpecificYear("=");
+  }
   if (instance && instance.refs && instance.refs.calendar) {
     (instance.refs.calendar as QCalendarMonth).moveToToday();
   }
 }
 
 function onPrev() {
+  if (viewMode.value == TIME_MAKER.YEAR) {
+    return goToSpecificYear("-");
+  }
   if (instance && instance.refs && instance.refs.calendar) {
     (instance.refs.calendar as QCalendarMonth).prev();
   }
 }
 
 function onNext() {
+  if (viewMode.value == TIME_MAKER.YEAR) {
+    return goToSpecificYear("+");
+  }
   if (instance && instance.refs && instance.refs.calendar) {
     (instance.refs.calendar as QCalendarMonth).next();
   }
@@ -170,12 +182,35 @@ onMounted(() => {
   loadSchedule();
 });
 async function goToSpecificMonth(targetYear: number, targetMonth: number) {
-  slideSchedule.value = "month";
+  viewMode.value = TIME_MAKER.MONTH;
   await nextTick();
   if (selectedDate) {
     const targetDate = `${targetYear}-${String(targetMonth).padStart(2, "0")}-01`;
     selectedDate.value = targetDate;
     await nextTick();
+  }
+}
+async function goToSpecificYear(opt: string) {
+  viewMode.value = TIME_MAKER.YEAR;
+  await nextTick();
+  if (selectedDate.value) {
+    const currentDate = DateTime.fromISO(selectedDate.value);
+    let targetYear = currentDate.year;
+    if (opt === "+") {
+      targetYear += 1;
+    }
+    if (opt === "-") {
+      targetYear -= 1;
+    }
+    if (opt === "=") {
+      targetYear = DateTime.now().year;
+    }
+    const targetDate = DateTime.fromObject({
+      year: targetYear,
+      month: 1,
+      day: 1,
+    }).toISODate();
+    selectedDate.value = targetDate;
   }
 }
 </script>

--- a/src/components/Schedule/CalendarSchedularRoom/ToolbarCalendar.vue
+++ b/src/components/Schedule/CalendarSchedularRoom/ToolbarCalendar.vue
@@ -13,7 +13,7 @@
     </q-item>
     <q-item>
       <q-item-section class="items-center font-custom">
-        <Month :select-date="props.date" />
+        <Month :select-date="props.date" :viewMode="props.viewMode" />
         <NavigationScheduleRoom
           @today="$emit('today')"
           @prev="$emit('prev')"
@@ -27,6 +27,10 @@
 <script setup lang="ts">
 const props = defineProps({
   date: {
+    type: String,
+    required: true,
+  },
+  viewMode: {
     type: String,
     required: true,
   },

--- a/src/components/Schedule/CardGridMonths/CardGridMonths.vue
+++ b/src/components/Schedule/CardGridMonths/CardGridMonths.vue
@@ -21,18 +21,45 @@
 <script setup lang="ts">
 import { monthsAux } from "../../../stores/months";
 import { useMonths } from "../../../stores/months";
+import {
+  RADIX_DECIMAL,
+  START_INDEX,
+  YEAR_LENGTH,
+} from "../../../support/constants";
+
+const props = defineProps({
+  year: {
+    type: String,
+    required: true,
+  },
+});
 const monthsStorage = useMonths();
 const emits = defineEmits(["envityMonth"]);
+
 onMounted(async () => {
-  await monthsStorage.loadEvents(monthsAux);
+  await monthsStorage.loadEvents(monthsAux, getYear());
 });
 
 async function goToSpecificMonth(monthName: string) {
   const month = monthsAux.find(
     (month) => month.label === monthName.toLowerCase(),
   );
-  emits("envityMonth", new Date().getFullYear(), month?.numberMonth);
+  emits("envityMonth", getYear(), month?.numberMonth);
 }
+
+const getYear = () => {
+  const yearString = props.year;
+  return parseInt(
+    yearString.substring(START_INDEX, YEAR_LENGTH),
+    RADIX_DECIMAL,
+  );
+};
+
+watchEffect(async () => {
+  if (props.year) {
+    await monthsStorage.loadEvents(monthsAux, getYear());
+  }
+});
 </script>
 
 <style scoped>

--- a/src/components/Schedule/ScheduleRoom/Month.vue
+++ b/src/components/Schedule/ScheduleRoom/Month.vue
@@ -1,7 +1,7 @@
 <template>
   <q-card class="text-h3 text-uppercase q-px-md">
     <div class="custom-color">
-      {{ formattedMonth }}
+      {{ labelMonth }}
     </div>
   </q-card>
 </template>
@@ -9,16 +9,30 @@
 <script setup lang="ts">
 import { DateTime } from "luxon";
 import { countryCodes } from "./lib";
+import { TIME_MAKER } from "../../../support/constants";
 const props = defineProps({
   selectDate: {
     type: String,
     default: "",
   },
+  viewMode: {
+    type: String,
+    required: true,
+  },
 });
-const formattedMonth = computed(() => {
+
+const labelMonth = ref();
+
+function formattedMonth() {
   const date = DateTime.fromISO(props.selectDate).toJSDate();
-  return monthFormatter().format(date) + " " + date.getFullYear();
-});
+  labelMonth.value = monthFormatter().format(date) + " " + date.getFullYear();
+}
+
+function formattedYear() {
+  const date = DateTime.fromISO(props.selectDate).toJSDate();
+  labelMonth.value = date.getFullYear();
+}
+
 const country = ref("BR");
 function monthFormatter(): Intl.DateTimeFormat {
   return new Intl.DateTimeFormat(locale.value || undefined, {
@@ -31,6 +45,12 @@ const locale = computed(() => {
     return countryCodes[country.value];
   }
   return "pt-BR";
+});
+watchEffect(() => {
+  if (props.viewMode === TIME_MAKER.MONTH) {
+    return formattedMonth();
+  }
+  return formattedYear();
 });
 </script>
 <style scoped>

--- a/src/components/Schedule/ScheduleRoom/NavigationScheduleRoom.vue
+++ b/src/components/Schedule/ScheduleRoom/NavigationScheduleRoom.vue
@@ -4,7 +4,6 @@
       <q-btn
         no-caps
         class="button color-custom text-uppercase bg-white"
-        style="margin: 2px"
         @click="$emit('prev')"
       >
         &lt; {{ $t("text.previous") }}
@@ -12,7 +11,6 @@
       <q-btn
         no-caps
         class="button color-custom text-uppercase bg-white"
-        style="margin: 2px"
         @click="$emit('today')"
       >
         {{ $t("text.now") }}
@@ -20,7 +18,6 @@
       <q-btn
         no-caps
         class="button color-custom text-uppercase bg-white"
-        style="margin: 2px"
         @click="$emit('next')"
       >
         {{ $t("text.next") }}

--- a/src/components/Schedule/ScheduleRoom/NavigationScheduleRoom.vue
+++ b/src/components/Schedule/ScheduleRoom/NavigationScheduleRoom.vue
@@ -5,17 +5,17 @@
         no-caps
         class="button color-custom text-uppercase bg-white"
         style="margin: 2px"
-        @click="$emit('today')"
+        @click="$emit('prev')"
       >
-        {{ $t("text.now") }}
+        &lt; {{ $t("text.previous") }}
       </q-btn>
       <q-btn
         no-caps
         class="button color-custom text-uppercase bg-white"
         style="margin: 2px"
-        @click="$emit('prev')"
+        @click="$emit('today')"
       >
-        &lt; {{ $t("text.previous") }}
+        {{ $t("text.now") }}
       </q-btn>
       <q-btn
         no-caps

--- a/src/graphql/scheduleRoom/LoadAllEventsInMonth.gql
+++ b/src/graphql/scheduleRoom/LoadAllEventsInMonth.gql
@@ -1,5 +1,5 @@
-query LoadAllEventsInMonth($month: String!) {
-  loadAllEventsInMonth(month: $month) {
+query LoadAllEventsInMonth($month: String!, $yearSelect: Int!) {
+  loadAllEventsInMonth(month: $month, yearSelect: $yearSelect) {
     id
     host {
       name

--- a/src/stores/months.ts
+++ b/src/stores/months.ts
@@ -53,12 +53,15 @@ export const useMonths = defineStore(id, {
   }),
   getters: {},
   actions: {
-    loadEvents: async (months: AuxMonth[]) => {
+    loadEvents: async (months: AuxMonth[], year: number) => {
       const monthsStorage = useMonths();
       monthsStorage.months = [];
       const promises = months.map(async (mes: AuxMonth) => {
         const { loadAllEventsInMonth }: { loadAllEventsInMonth: EventRoom[] } =
-          await runQuery(LoadAllEventsInMonth, { month: mes.label });
+          await runQuery(LoadAllEventsInMonth, {
+            month: mes.label,
+            yearSelect: year,
+          });
         return {
           name: mes.label,
           events: loadAllEventsInMonth,
@@ -69,7 +72,6 @@ export const useMonths = defineStore(id, {
       monthsStorage.months = monthsData.sort((a, b) => a.value - b.value);
     },
     previousMonth: async (monthName: string) => {
-      const monthsStorage = useMonths();
       const { loadAllEventsInMonth }: { loadAllEventsInMonth: EventRoom[] } =
         await runQuery(LoadAllEventsInMonth, {
           month: getPreviousMonth(monthName),
@@ -80,7 +82,6 @@ export const useMonths = defineStore(id, {
       };
     },
     nextMonth: async (monthName: string) => {
-      const monthsStorage = useMonths();
       const { loadAllEventsInMonth }: { loadAllEventsInMonth: EventRoom[] } =
         await runQuery(LoadAllEventsInMonth, {
           month: getNextMonth(monthName),

--- a/src/support/constants.ts
+++ b/src/support/constants.ts
@@ -1,0 +1,11 @@
+export const START_INDEX = 0;
+export const RADIX_DECIMAL = 10;
+export const YEAR_LENGTH = 4;
+
+export enum TIME_MAKER {
+  YEAR = "year",
+  MONTH = "month",
+  DAY = "day",
+}
+
+export const MIN_DAY_HEIGHT = 100;


### PR DESCRIPTION
Este PR implementa a funcionalidade de navegação entre anos no calendário e permite a exibição de eventos nos meses correspondentes. As principais alterações incluem:

- Adição de controles para navegação entre anos.
- Atualização da visualização de eventos para exibir eventos associados aos meses do ano selecionado.

Revisem as mudanças e verifiquem se a navegação entre anos e a exibição de eventos estão funcionando conforme o esperado.
![2024-07-30_14-36](https://github.com/user-attachments/assets/b5d2f94a-985c-47ec-a38d-d0bd5cf7125d)
![image](https://github.com/user-attachments/assets/d0fdb880-f6d3-4271-8673-5c74b218c1f2)
