### PR TITLE
✨ Adiciona card para exibir eventos da semana

### DIFF
--- a/src/components/Pages/PageScheduleRoom/PScheduleRoom.vue
+++ b/src/components/Pages/PageScheduleRoom/PScheduleRoom.vue
@@ -52,6 +52,7 @@
           :reloadCard="reloadCardGridMonths"
           @reloadDesactive="reloadCardGridMonths = false"
         />
+        <CardWeekSchedule v-if="viewMode === TIME_MAKER.WEEK" />
       </q-slide-transition>
     </div>
   </div>

--- a/src/components/Schedule/ScheduleRoom/AuxButtonsForSchedule/ButtonGoScheduleYear.vue
+++ b/src/components/Schedule/ScheduleRoom/AuxButtonsForSchedule/ButtonGoScheduleYear.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script setup lang="ts">
-const items = ["month", "year"];
+const items = ["month", "year", "week"];
 const emits = defineEmits(["changeSchedule"]);
 const selectedItem = ref<string | null>("month");
 

--- a/src/components/Schedule/WeekSchedule/BadgeEventsInWeekSchedule.vue
+++ b/src/components/Schedule/WeekSchedule/BadgeEventsInWeekSchedule.vue
@@ -1,0 +1,72 @@
+<template>
+  <div v-for="(event, index) in getEventsByDate(props.data)">
+    <div v-if="shouldDisplayEvent(index)" cliclable @click="selectEvent(event)">
+      <q-badge
+        rounded
+        :style="`background-color:${event.location.color}`"
+        class="justify-center q-py-sm q-px-xl text-black"
+      >
+        {{ event.host.name }}
+      </q-badge>
+    </div>
+  </div>
+  <q-dialog v-model="card">
+    <q-card>
+      <q-card-section class="custom-color row justify-between text-white">
+        <div class="q-pa-md text-h5 font-custom text-white">
+          {{ eventSelect.rules }}
+        </div>
+        <q-icon
+          name="close"
+          class="pt-2 cursor-pointer"
+          size="45px"
+          @click="card = !card"
+        />
+      </q-card-section>
+      <DialogScheduleRoom :event-show="eventSelect" />
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { DateTime } from "luxon";
+import { EventRoom } from "../../../entities/scheduleRoom";
+import { formatDate } from "../ScheduleRoom/lib";
+const MAX_EVENTS = 8;
+const props = defineProps({
+  data: {
+    type: String,
+    default: "",
+  },
+  events: {
+    type: Array as () => EventRoom[],
+    default: () => [],
+  },
+});
+const eventSelect = ref();
+const card = ref(false);
+
+function getEventsByDate(date: string) {
+  return props.events.filter((event) => {
+    const eventDate = new Date(event.finalTime.toString());
+    return formatDate(eventDate) === date;
+  });
+}
+const shouldDisplayEvent = computed(
+  () => (index: number) => index < MAX_EVENTS,
+);
+function selectEvent(event: EventRoom) {
+  const initialTime = DateTime.fromISO(event.initialTime.toString()).plus({
+    hours: 3,
+  });
+  const finalTime = DateTime.fromISO(event.finalTime.toString()).plus({
+    hours: 3,
+  });
+  const auxEvent = {
+    ...event,
+    initialTime: DateTime.fromISO(initialTime.toString()),
+    finalTime: DateTime.fromISO(finalTime.toString()),
+  };
+  eventSelect.value = auxEvent;
+}
+</script>

--- a/src/components/Schedule/WeekSchedule/CardWeekSchedule.vue
+++ b/src/components/Schedule/WeekSchedule/CardWeekSchedule.vue
@@ -1,0 +1,63 @@
+<template>
+  <q-calendar-agenda
+    ref="calendar"
+    class="agenda-size"
+    v-model="selectedDate"
+    view="week"
+    :day-min-height="MIN_DAY_HEIGHT"
+    bordered
+    animated
+    locale="pt-br"
+  >
+    <template #day="{ scope: { timestamp } }">
+      <BadgeEventsInWeekSchedule :data="timestamp.date" :events="events" />
+    </template>
+  </q-calendar-agenda>
+</template>
+
+<script setup lang="ts">
+import { QCalendarAgenda, today } from "@quasar/quasar-ui-qcalendar/";
+import "@quasar/quasar-ui-qcalendar/src/QCalendarVariables.sass";
+import "@quasar/quasar-ui-qcalendar/src/QCalendarTransitions.sass";
+import "@quasar/quasar-ui-qcalendar/src/QCalendarAgenda.sass";
+import { MIN_DAY_HEIGHT } from "../../../support/constants";
+import { createEvent, getHeadDay } from "../ScheduleRoom/lib";
+import ScheduleRoomLoad from "../../../graphql/scheduleRoom/ScheduleRoomLoad.gql";
+import { DateTime } from "luxon";
+import { EventRoom } from "../../../entities/scheduleRoom";
+
+const selectedDate = ref(today());
+const events = ref();
+
+async function loadSchedule() {
+  const { scheduleRoomLoad } = (await runQuery(ScheduleRoomLoad)) as {
+    scheduleRoomLoad: EventRoom[];
+  };
+  scheduleRoomLoad.forEach((event) => {
+    const initialTime = DateTime.fromISO(event.initialTime.toString()).plus({
+      hours: 3,
+    });
+    const finalTime = DateTime.fromISO(event.finalTime.toString()).plus({
+      hours: 3,
+    });
+
+    event.initialTime = DateTime.fromISO(initialTime.toString());
+    event.finalTime = DateTime.fromISO(finalTime.toString());
+  });
+  events.value = createEvent(scheduleRoomLoad);
+}
+
+onMounted(() => {
+  loadSchedule();
+});
+</script>
+<style scoped>
+.custom-color {
+  background-color: rgb(31, 73, 125);
+}
+.agenda-size {
+  height: 40rem;
+  max-height: 45rem;
+  overflow-y: scroll;
+}
+</style>

--- a/src/support/constants.ts
+++ b/src/support/constants.ts
@@ -6,6 +6,7 @@ export enum TIME_MAKER {
   YEAR = "year",
   MONTH = "month",
   DAY = "day",
+  WEEK = "week",
 }
 
 export const MIN_DAY_HEIGHT = 100;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3115,27 +3115,26 @@
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-5.0.5.tgz#e3dc11e427d4b818b7e3202766ad156e3d5e2eaa"
   integrity sha512-LOjm7XeIimLBZyzinBQ6OSm3UBCNVCpLkxGC0oWmm2YPzVZoxMsdvNVimLTBzpAnR9hl/yn1SHGuRfe6/Td9rQ==
 
-"@volar/language-core@1.11.1", "@volar/language-core@~1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@volar/language-core/-/language-core-1.11.1.tgz#ecdf12ea8dc35fb8549e517991abcbf449a5ad4f"
-  integrity sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==
+"@volar/language-core@2.4.0-alpha.18", "@volar/language-core@~2.4.0-alpha.18":
+  version "2.4.0-alpha.18"
+  resolved "https://registry.yarnpkg.com/@volar/language-core/-/language-core-2.4.0-alpha.18.tgz#dafffd68ac07c26d69de16741187fd4c06bfa345"
+  integrity sha512-JAYeJvYQQROmVRtSBIczaPjP3DX4QW1fOqW1Ebs0d3Y3EwSNRglz03dSv0Dm61dzd0Yx3WgTW3hndDnTQqgmyg==
   dependencies:
-    "@volar/source-map" "1.11.1"
+    "@volar/source-map" "2.4.0-alpha.18"
 
-"@volar/source-map@1.11.1", "@volar/source-map@~1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-1.11.1.tgz#535b0328d9e2b7a91dff846cab4058e191f4452f"
-  integrity sha512-hJnOnwZ4+WT5iupLRnuzbULZ42L7BWWPMmruzwtLhJfpDVoZLjNBxHDi2sY2bgZXCKlpU5XcsMFoYrsQmPhfZg==
-  dependencies:
-    muggle-string "^0.3.1"
+"@volar/source-map@2.4.0-alpha.18":
+  version "2.4.0-alpha.18"
+  resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-2.4.0-alpha.18.tgz#a2413932ff6b1821ae8efcbd9249d4da3f99f223"
+  integrity sha512-MTeCV9MUwwsH0sNFiZwKtFrrVZUK6p8ioZs3xFzHc2cvDXHWlYN3bChdQtwKX+FY2HG6H3CfAu1pKijolzIQ8g==
 
-"@volar/typescript@~1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@volar/typescript/-/typescript-1.11.1.tgz#ba86c6f326d88e249c7f5cfe4b765be3946fd627"
-  integrity sha512-iU+t2mas/4lYierSnoFOeRFQUhAEMgsFuQxoxvwn5EdQopw43j+J27a4lt9LMInx1gLJBC6qL14WYGlgymaSMQ==
+"@volar/typescript@~2.4.0-alpha.18":
+  version "2.4.0-alpha.18"
+  resolved "https://registry.yarnpkg.com/@volar/typescript/-/typescript-2.4.0-alpha.18.tgz#806aca9ce1bd7c48dc5fcd0fcf7f33bdd04e5b35"
+  integrity sha512-sXh5Y8sqGUkgxpMWUGvRXggxYHAVxg0Pa1C42lQZuPDrW6vHJPR0VCK8Sr7WJsAW530HuNQT/ZIskmXtxjybMQ==
   dependencies:
-    "@volar/language-core" "1.11.1"
+    "@volar/language-core" "2.4.0-alpha.18"
     path-browserify "^1.0.1"
+    vscode-uri "^3.0.8"
 
 "@vue/compiler-core@3.4.31", "@vue/compiler-core@^3.0.0":
   version "3.4.31"
@@ -3148,13 +3147,32 @@
     estree-walker "^2.0.2"
     source-map-js "^1.2.0"
 
-"@vue/compiler-dom@3.4.31", "@vue/compiler-dom@^3.3.0":
+"@vue/compiler-core@3.4.35":
+  version "3.4.35"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.4.35.tgz#421922a75ecabf1aabc6b7a2ce98b5acb2fc2d65"
+  integrity sha512-gKp0zGoLnMYtw4uS/SJRRO7rsVggLjvot3mcctlMXunYNsX+aRJDqqw/lV5/gHK91nvaAAlWFgdVl020AW1Prg==
+  dependencies:
+    "@babel/parser" "^7.24.7"
+    "@vue/shared" "3.4.35"
+    entities "^4.5.0"
+    estree-walker "^2.0.2"
+    source-map-js "^1.2.0"
+
+"@vue/compiler-dom@3.4.31":
   version "3.4.31"
   resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.4.31.tgz#30961ca847f5d6ad18ffa26236c219f61b195f6b"
   integrity sha512-wK424WMXsG1IGMyDGyLqB+TbmEBFM78hIsOJ9QwUVLGrcSk0ak6zYty7Pj8ftm7nEtdU/DGQxAXp0/lM/2cEpQ==
   dependencies:
     "@vue/compiler-core" "3.4.31"
     "@vue/shared" "3.4.31"
+
+"@vue/compiler-dom@^3.4.0":
+  version "3.4.35"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.4.35.tgz#cd0881f1b4ed655cd96367bce4845f87023a5a2d"
+  integrity sha512-pWIZRL76/oE/VMhdv/ovZfmuooEni6JPG1BFe7oLk5DZRo/ImydXijoZl/4kh2406boRQ7lxTYzbZEEXEhj9NQ==
+  dependencies:
+    "@vue/compiler-core" "3.4.35"
+    "@vue/shared" "3.4.35"
 
 "@vue/compiler-sfc@3.4.31":
   version "3.4.31"
@@ -3179,25 +3197,32 @@
     "@vue/compiler-dom" "3.4.31"
     "@vue/shared" "3.4.31"
 
+"@vue/compiler-vue2@^2.7.16":
+  version "2.7.16"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz#2ba837cbd3f1b33c2bc865fbe1a3b53fb611e249"
+  integrity sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==
+  dependencies:
+    de-indent "^1.0.2"
+    he "^1.2.0"
+
 "@vue/devtools-api@^6.5.0", "@vue/devtools-api@^6.5.1", "@vue/devtools-api@^6.6.1":
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.6.3.tgz#b23a588154cba8986bba82b6e1d0248bde3fd1a0"
   integrity sha512-0MiMsFma/HqA6g3KLKn+AGpL1kgKhFWszC9U29NfpWK5LE7bjeXxySWJrOJ77hBz+TBrBQ7o4QJqbPbqbs8rJw==
 
-"@vue/language-core@1.8.27":
-  version "1.8.27"
-  resolved "https://registry.yarnpkg.com/@vue/language-core/-/language-core-1.8.27.tgz#2ca6892cb524e024a44e554e4c55d7a23e72263f"
-  integrity sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==
+"@vue/language-core@2.0.29":
+  version "2.0.29"
+  resolved "https://registry.yarnpkg.com/@vue/language-core/-/language-core-2.0.29.tgz#19462d786cd7a1c21dbe575b46970a57094e0357"
+  integrity sha512-o2qz9JPjhdoVj8D2+9bDXbaI4q2uZTHQA/dbyZT4Bj1FR9viZxDJnLcKVHfxdn6wsOzRgpqIzJEEmSSvgMvDTQ==
   dependencies:
-    "@volar/language-core" "~1.11.1"
-    "@volar/source-map" "~1.11.1"
-    "@vue/compiler-dom" "^3.3.0"
-    "@vue/shared" "^3.3.0"
+    "@volar/language-core" "~2.4.0-alpha.18"
+    "@vue/compiler-dom" "^3.4.0"
+    "@vue/compiler-vue2" "^2.7.16"
+    "@vue/shared" "^3.4.0"
     computeds "^0.0.1"
     minimatch "^9.0.3"
-    muggle-string "^0.3.1"
+    muggle-string "^0.4.1"
     path-browserify "^1.0.1"
-    vue-template-compiler "^2.7.14"
 
 "@vue/reactivity@3.4.31":
   version "3.4.31"
@@ -3232,10 +3257,15 @@
     "@vue/compiler-ssr" "3.4.31"
     "@vue/shared" "3.4.31"
 
-"@vue/shared@3.4.31", "@vue/shared@^3.3.0":
+"@vue/shared@3.4.31":
   version "3.4.31"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.4.31.tgz#af9981f57def2c3f080c14bf219314fc0dc808a0"
   integrity sha512-Yp3wtJk//8cO4NItOPpi3QkLExAr/aLBGZMmTtW9WpdwBCJpRM6zj9WgWktXAl8IDIozwNMByT45JP3tO3ACWA==
+
+"@vue/shared@3.4.35", "@vue/shared@^3.4.0":
+  version "3.4.35"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.4.35.tgz#5432f4b1c79e763fcf78cc830faf59ff01248968"
+  integrity sha512-hvuhBYYDe+b1G8KHxsQ0diDqDMA8D9laxWZhNAjE83VZb5UDaXl9Xnz7cGdDSyiHM90qqI/CyGMcpBpiDy6VVQ==
 
 "@vueuse/core@^10.9.0":
   version "10.11.0"
@@ -6296,10 +6326,10 @@ ms@2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-muggle-string@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/muggle-string/-/muggle-string-0.3.1.tgz#e524312eb1728c63dd0b2ac49e3282e6ed85963a"
-  integrity sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==
+muggle-string@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/muggle-string/-/muggle-string-0.4.1.tgz#3b366bd43b32f809dc20659534dd30e7c8a0d328"
+  integrity sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==
 
 mute-stream@0.0.8:
   version "0.0.8"
@@ -8030,6 +8060,11 @@ vite@^5.1.4:
   optionalDependencies:
     fsevents "~2.3.3"
 
+vscode-uri@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.8.tgz#1770938d3e72588659a172d0fd4642780083ff9f"
+  integrity sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==
+
 vue-component-type-helpers@latest:
   version "2.0.26"
   resolved "https://registry.yarnpkg.com/vue-component-type-helpers/-/vue-component-type-helpers-2.0.26.tgz#6355f1a683ff627e8da74e6a61e2122b3e10ed06"
@@ -8089,21 +8124,13 @@ vue-styled-components@^1.6.0:
     lodash.zipobject "^4.1.3"
     stylis "^3.5.4"
 
-vue-template-compiler@^2.7.14:
-  version "2.7.16"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz#c81b2d47753264c77ac03b9966a46637482bb03b"
-  integrity sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==
+vue-tsc@^2.0.26:
+  version "2.0.29"
+  resolved "https://registry.yarnpkg.com/vue-tsc/-/vue-tsc-2.0.29.tgz#bf7e9605af9fadec7fd6037d242217f5c6ad2c3b"
+  integrity sha512-MHhsfyxO3mYShZCGYNziSbc63x7cQ5g9kvijV7dRe1TTXBRLxXyL0FnXWpUF1xII2mJ86mwYpYsUmMwkmerq7Q==
   dependencies:
-    de-indent "^1.0.2"
-    he "^1.2.0"
-
-vue-tsc@^1.8.27:
-  version "1.8.27"
-  resolved "https://registry.yarnpkg.com/vue-tsc/-/vue-tsc-1.8.27.tgz#feb2bb1eef9be28017bb9e95e2bbd1ebdd48481c"
-  integrity sha512-WesKCAZCRAbmmhuGl3+VrdWItEvfoFIPXOvUJkjULi+x+6G/Dy69yO3TBRJDr9eUlmsNAwVmxsNZxvHKzbkKdg==
-  dependencies:
-    "@volar/typescript" "~1.11.1"
-    "@vue/language-core" "1.8.27"
+    "@volar/typescript" "~2.4.0-alpha.18"
+    "@vue/language-core" "2.0.29"
     semver "^7.5.4"
 
 vue@^3.4.21:


### PR DESCRIPTION
Este PR adiciona um novo card à nossa visualização semanal de eventos no calendário. Abaixo estão os detalhes das mudanças realizadas:

+Criação do Card de Eventos Semanais: Implementamos um card que exibe todos os eventos para a semana atual, proporcionando uma visão consolidada dos compromissos e atividades programadas.

+Exibição dos Eventos: O card é projetado para mostrar eventos de forma clara e organizada, com informações importantes como o nome do host e a localização. A exibição é limitada a um número máximo de eventos para garantir que a interface permaneça limpa e utilizável.

![image](https://github.com/user-attachments/assets/d76da7dc-1984-443a-bceb-6a7282391f90)
